### PR TITLE
Fix server startup error when port already in use

### DIFF
--- a/index.js
+++ b/index.js
@@ -1656,13 +1656,11 @@ async function sendDashboardUpdate(data) {
 
 // הפעלת השרת
 const PORT = process.env.PORT || 3003;
-const startServer = async (port) => {
+const startServer = (port) => {
     const stage = "SERVER_STARTUP";
-    try {
-        http.listen(port, () => {
-            log(`השרת פועל על פורט ${port}`, stage);
-        });
-    } catch (error) {
+    http.listen(port, () => {
+        log(`השרת פועל על פורט ${port}`, stage);
+    }).on('error', (error) => {
         if (error.code === 'EADDRINUSE') {
             logError(`פורט ${port} תפוס, מנסה פורט ${port + 1}`, stage, error);
             startServer(port + 1);
@@ -1670,7 +1668,7 @@ const startServer = async (port) => {
             logError(`שגיאה קריטית בהפעלת השרת: ${error.message}. יוצא מהתהליך.`, stage, error);
             process.exit(1);
         }
-    }
+    });
 };
 
 startServer(PORT);


### PR DESCRIPTION
## Summary
- handle `EADDRINUSE` during server startup by listening to the `error` event

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685bef040e1c8323b17e7fbbace9c761