### PR TITLE
Add Telegram bot to manage blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-"# spam_botme" 
+# spam_botme
+
+This project contains a WhatsApp bot and now also includes a Telegram bot.
+
+Running `node index.js` will start both bots. The Telegram bot helps manage the
+`blacklist.json` file that is shared with the WhatsApp bot.
+
+### Telegram Commands
+
+- `/start` – display information and available commands.
+- `/blacklist` – view the blacklist with simple pagination.
+- `/add` – add a phone number to the blacklist.
+- `/remove` – remove a phone number from the blacklist.
+
+Numbers can be sent in local or international format (e.g. `0501234567` or
+`972501234567`).


### PR DESCRIPTION
## Summary
- integrate `node-telegram-bot-api` and start Telegram bot alongside the WhatsApp bot
- handle `/start`, `/blacklist`, `/add` and `/remove` commands
- synchronize Telegram actions with `blacklist.json`
- document Telegram commands in README

## Testing
- `node --check index.js`

------
https://chatgpt.com/codex/tasks/task_e_685bf02b6fc48323b8c406325304672c