### PR TITLE
Improve server port handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -1671,11 +1671,11 @@ async function sendDashboardUpdate(data) {
 const PORT = process.env.PORT || 3003;
 const startServer = async (port) => {
     const stage = "SERVER_STARTUP";
-    try {
-        http.listen(port, () => {
-            log(`השרת פועל על פורט ${port}`, stage);
-        });
-    } catch (error) {
+    const server = http.listen(port, () => {
+        log(`השרת פועל על פורט ${port}`, stage);
+    });
+
+    server.on('error', (error) => {
         if (error.code === 'EADDRINUSE') {
             logError(`פורט ${port} תפוס, מנסה פורט ${port + 1}`, stage, error);
             startServer(port + 1);
@@ -1683,7 +1683,7 @@ const startServer = async (port) => {
             logError(`שגיאה קריטית בהפעלת השרת: ${error.message}. יוצא מהתהליך.`, stage, error);
             process.exit(1);
         }
-    }
+    });
 };
 
 startServer(PORT);


### PR DESCRIPTION
## Summary
- fix server to listen for `error` events when starting up
- gracefully handle address-in-use situation

## Testing
- `node index.js` *(fails: Cannot find module 'qrcode-terminal')*

------
https://chatgpt.com/codex/tasks/task_e_685bf14be6a08323b4c28727f087d6df