### PR TITLE
Add auto-approval for WhatsApp join requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ Running `node index.js` will start both bots. The Telegram bot helps manage the
 
 Numbers can be sent in local or international format (e.g. `0501234567` or
 `972501234567`).
+
+The WhatsApp bot periodically checks pending join requests in all managed
+groups. Requests from numbers found in `blacklist.json` are rejected while all
+others are approved automatically.


### PR DESCRIPTION
## Summary
- automatically approve or reject WhatsApp membership requests every minute
- reject users in `blacklist.json`
- document the new behaviour

## Testing
- `node --check index.js`
- `node --check join-requests.js`

------
https://chatgpt.com/codex/tasks/task_e_6865211e4d0c8323a05d4f4230e96e52